### PR TITLE
fix svelte-lazy-loader usage, remove inView

### DIFF
--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -1,69 +1,66 @@
 <script context="module">
-    // Vanilla lazy loading: https://dev.to/ekafyi/lazy-loading-images-with-vanilla-javascript-2fbj 
-    // Svelte lazy loading: https://css-tricks.com/lazy-loading-images-in-svelte/ 
-    // MDN responsive images: https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images
-    // Sharp documentation: https://sharp.pixelplumbing.com 
-    import {client} from '@lib/api/graphql-client'
-    import {projectsQuery} from '@lib/api/graphql-queries'
+	// Vanilla lazy loading: https://dev.to/ekafyi/lazy-loading-images-with-vanilla-javascript-2fbj
+	// Svelte lazy loading: https://css-tricks.com/lazy-loading-images-in-svelte/
+	// MDN responsive images: https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images
+	// Sharp documentation: https://sharp.pixelplumbing.com
+	import { client } from '@lib/api/graphql-client';
+	import { projectsQuery } from '@lib/api/graphql-queries';
 
-    export const load = async () => {
-        
-        let width = 1500;
-        let height = 1200;
-        const variables = {width: width, height: height}
+	export const load = async () => {
+		let width = 1500;
+		let height = 1200;
+		const variables = { width: width, height: height };
 
-        const {projects} = await client.request(projectsQuery, variables)
+		const { projects } = await client.request(projectsQuery, variables);
 
-        return {
-            props: {
-                projects,
-            }
-        }
-    }
+		return {
+			props: {
+				projects
+			}
+		};
+	};
 </script>
+
 <script>
-    import Image from '@components/Image/Image.svelte'
-    import {inview} from 'svelte-inview'
-    import {fade} from 'svelte/transition'
-    
-    export let projects;
-    let height;
-    let width;
+	import Image from '@components/Image/Image.svelte';
 
-    let base64pixel = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAJCAQAAACRI2S5AAAAEklEQVR42mNMkmTACxhHFYABAMtfBF25QVgfAAAAAElFTkSuQmCC"
+	export let projects;
+	let height;
+	let width;
 
-    let isInView;
-    const options = {
-        rootMargin: '-20%',
-        threshold: '0.05',
-        unobserveOnEnter: true,
-    };
-
-    const handleChange = ({ detail }) => (isInView = detail.inView);
+	let base64pixel =
+		'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAJCAQAAACRI2S5AAAAEklEQVR42mNMkmTACxhHFYABAMtfBF25QVgfAAAAAElFTkSuQmCC';
 </script>
-
-
-
 
 <div class="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-8 pb-4">
-    {#each projects.slice(0, 2) as project}
-        <div bind:offsetHeight={height} bind:offsetWidth={width}>
-            <img {height} {width} alt="project img" src="{project.image[0].url}"/>
-        </div>
-    {/each}
+	{#each projects.slice(0, 2) as project}
+		<div bind:offsetHeight={height} bind:offsetWidth={width}>
+			<!-- could use srcset here as well to define multiple images -->
+			<Image
+				height="{height}px"
+				width="{width}px"
+				alt="project img"
+				placeholder={base64pixel}
+				src={project.image[0].url}
+			/>
+		</div>
+	{/each}
 </div>
 <div class="grid grid-cols-1 gap-4 md:gap-8">
-    {#each projects.slice(2, projects.length) as project}
-        <div bind:offsetHeight={height} bind:offsetWidth={width} use:inview="{options}" on:change="{handleChange}">
-            {#if isInView}
-                <div in:fade="{{duration: 300 }}">
-                    <Image {height} {width} alt="project img" src="{project.image[0].url}"/>
-                </div>
-            {:else}
-                <img {height} {width} alt="project img" src="{base64pixel}"/>
-            {/if}
-        </div>
-    {/each}
+	{#each projects.slice(2, projects.length) as project}
+		<div bind:offsetHeight={height} bind:offsetWidth={width}>
+			<div>
+				<!-- could use srcset here as well to define multiple images -->
+				<Image
+					height="{height}px"
+					width="{width}px"
+					alt="project img"
+					placeholder={base64pixel}
+					src={project.image[0].url}
+				/>
+			</div>
+		</div>
+	{/each}
 </div>
 
 <!--Pass width and height as props to Image component. Inside image component, graphQlRequest for that specific image.-->


### PR DESCRIPTION
Hi! creator of svelte-lazy-loader here 👋. I noticed some incorrect usage of the Image component and have made some adjustments here that I think would work best with [svelte-lazy-loader's api](https://www.npmjs.com/package/svelte-lazy-loader#api):

- base64pixel var can be passed via the `placeholder prop`. it will remain as the placeholder until the user scrolls into view, which will then cause your prop of `src={project.image[0].url}` to be the src
- width and height need units (just like a regular img element), so I reworked them to be `height="{height}px" width="{width}px"`

I've removed inView altogether. svelte-lazy-loader uses IntersectionObserver under the hood already

Another note: You could pass a `srcset` prop to the Image to create defined versions similar to the <img/> element. If you have different formats, I suggest checking out the [Picture component](https://www.npmjs.com/package/svelte-lazy-loader#picture) in svelte-lazy-loader.